### PR TITLE
build(pom): bump sling-bundle-parent to v66 and clean up scm/deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>49</version>
+        <version>66</version>
         <relativePath />
     </parent>
 
@@ -35,11 +35,10 @@
 
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-hapi-client.git</connection>
-        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-hapi-client.git
-        </developerConnection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-hapi-client.git</developerConnection>
+        <tag>HEAD</tag>
         <url>https://github.com/apache/sling-org-apache-sling-hapi-client.git</url>
-      <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <properties>
         <sling.java.version>8</sling.java.version>
@@ -81,11 +80,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.36</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updates the Maven POM to use a newer parent POM version and removes a redundant dependency.

- Bump `sling-bundle-parent` version from 49 to 66
- Fix formatting of `<developerConnection>` element (collapse to single line)
- Move `<tag>HEAD</tag>` inside `<scm>` with consistent indentation
- Remove redundant `osgi.core` provided dependency (superseded by `org.osgi.service.component`)

Co-authored-by: Maia <maia@noreply>